### PR TITLE
added lein version as prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 A work-in-progress CQRS/Rest frameworky thing. Backed by [Onyx](https://github.com/onyx-platform/onyx).
 Basically an implementation of the design mentioned here: [From REST to CQRS](https://www.youtube.com/watch?v=qDNPQo9UmJA)
 
+## Prerequisites
+
+Leiningen 2.6.1
 
 ## Usage
 


### PR DESCRIPTION
I was getting this error for a while:

```
Exception in thread "main" java.lang.RuntimeException: Unable to resolve var: cemerick.piggieback/wrap-cljs-repl in this context
```

I suspect it's due to this bug: https://github.com/technomancy/leiningen/issues/1771. It tripped me up for a while so I thought I'd suggest adding a note to the readme.
